### PR TITLE
Configuration changes for PAAS deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,5 +133,8 @@ dmypy.json
 
 # TAP Project
 /static
-/external_static
 /reports
+node_modules
+
+#CSS
+web/core/static/core/css/styles.css

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn config.wsgi:application --bind 0.0.0.0:$PORT --timeout 300 --log-file -
+web: python manage.py migrate --noinput && python manage.py compilescss && python manage.py collectstatic --noinput && gunicorn config.wsgi:application --bind 0.0.0.0:$PORT --timeout 300 --log-file -

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'sass_processor',
     'django_filters',
 ] + TAP_APPS
 
@@ -147,9 +148,15 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
 STATIC_ROOT = os.path.join(BASE_DIR, '..', 'static')
+
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, '..', 'external_static'),
+    os.path.join(BASE_DIR, '..', 'node_modules/govuk-frontend'),
+]
+
+SASS_PROCESSOR_INCLUDE_DIRS = [
+    os.path.join(BASE_DIR, '..', 'node_modules'),
 ]
 
 # https://www.django-rest-framework.org/

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,10 +16,17 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls import url
 from django.urls import path, include
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, RedirectView
 from material.frontend import urls as viewflow_frontend_urls
 
 urlpatterns = [
+    # The govuk-frontend stylesheet requires a specific assets location
+    # eg. node_modules/govuk-frontend/govuk/helpers/_font-faces.scss
+    path(
+        "assets/<path:asset_path>",
+        RedirectView.as_view(url="/static/govuk/assets/%(asset_path)s"),
+    ),
+
     # Viewflow urls includes django '/admin' and '/accounts'
     path('', include(viewflow_frontend_urls)),
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,4 @@
 applications:
-  - name: trade-access-dev
-    instances: 1
-    buildpacks:
+  - buildpacks:
+      - https://github.com/cloudfoundry/nodejs-buildpack.git
       - https://github.com/cloudfoundry/python-buildpack.git
-    services:
-      - pg-trade-access-dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "trade-access-program",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "govuk-frontend": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
+      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "trade-access-program",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "node": "12.18.x"
+  },
+  "dependencies": {
+    "govuk-frontend": "^3.7.0"
+  }
+}

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,10 +1,13 @@
 Django==3.0.7
-psycopg2==2.8.5
-djangorestframework==3.11.0
+django-compressor==2.4
 django-environ==0.4.5
 django-filter==2.3.0
 django-material==1.6.3
+django-sass-processor==0.8
 django-viewflow==1.6.0
-requests==2.24.0
+djangorestframework==3.11.0
 gunicorn==19.9.0
+libsass==0.20.0
+psycopg2==2.8.5
+requests==2.24.0
 whitenoise==5.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,19 +8,25 @@ asgiref==3.2.9            # via django
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 django-annoying==0.10.6   # via django-viewflow
+django-appconf==1.0.4     # via django-compressor
+django-compressor==2.4    # via -r requirements/base.in
 django-environ==0.4.5     # via -r requirements/base.in
 django-filter==2.3.0      # via -r requirements/base.in, django-viewflow
 django-jsonstore==0.4.1   # via django-viewflow
 django-material==1.6.3    # via -r requirements/base.in
+django-sass-processor==0.8  # via -r requirements/base.in
 django-viewflow==1.6.0    # via -r requirements/base.in
 django==3.0.7             # via -r requirements/base.in, django-filter, django-viewflow, djangorestframework
 djangorestframework==3.11.0  # via -r requirements/base.in
 gunicorn==19.9.0          # via -r requirements/base.in
 idna==2.10                # via requests
+libsass==0.20.0           # via -r requirements/base.in
 psycopg2==2.8.5           # via -r requirements/base.in
 pytz==2020.1              # via django
+rcssmin==1.0.6            # via django-compressor
 requests==2.24.0          # via -r requirements/base.in
-six==1.15.0               # via django-material, django-viewflow
+rjsmin==1.1.0             # via django-compressor
+six==1.15.0               # via django-compressor, django-material, django-viewflow, libsass
 sqlparse==0.3.1           # via django
 urllib3==1.25.9           # via requests
 whitenoise==5.1.0         # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,13 +13,16 @@ chardet==3.0.4            # via -r requirements/base.txt, requests
 coverage==5.2             # via pytest-cov
 decorator==4.4.2          # via ipython, traitlets
 django-annoying==0.10.6   # via -r requirements/base.txt, django-viewflow
+django-appconf==1.0.4     # via -r requirements/base.txt, django-compressor
+django-compressor==2.4    # via -r requirements/base.txt
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-environ==0.4.5     # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt, django-viewflow
 django-jsonstore==0.4.1   # via -r requirements/base.txt, django-viewflow
 django-material==1.6.3    # via -r requirements/base.txt
+django-sass-processor==0.8  # via -r requirements/base.txt
 django-viewflow==1.6.0    # via -r requirements/base.txt
-django==3.0.7             # via -r requirements/base.txt, django-annoying, django-debug-toolbar, django-filter, django-jsonstore, django-viewflow, djangorestframework
+django==3.0.7             # via -r requirements/base.txt, django-annoying, django-appconf, django-debug-toolbar, django-filter, django-jsonstore, django-viewflow, djangorestframework
 djangorestframework==3.11.0  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/dev.in
 faker==4.1.1              # via factory-boy
@@ -31,6 +34,7 @@ ipdb==0.13.3              # via -r requirements/dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.15.0           # via ipdb
 jedi==0.17.1              # via ipython
+libsass==0.20.0           # via -r requirements/base.txt
 mccabe==0.6.1             # via flake8
 more-itertools==8.4.0     # via pytest
 packaging==20.4           # via pytest, pytest-sugar
@@ -54,8 +58,10 @@ pytest==5.4.3             # via -r requirements/dev.in, pytest-cov, pytest-djang
 python-dateutil==2.8.1    # via faker
 python-dotenv==0.13.0     # via pytest-dotenv
 pytz==2020.1              # via -r requirements/base.txt, django
+rcssmin==1.0.6            # via -r requirements/base.txt, django-compressor
 requests==2.24.0          # via -r requirements/base.txt
-six==1.15.0               # via -r requirements/base.txt, django-annoying, django-jsonstore, django-material, django-viewflow, packaging, python-dateutil, traitlets
+rjsmin==1.1.0             # via -r requirements/base.txt, django-compressor
+six==1.15.0               # via -r requirements/base.txt, django-annoying, django-compressor, django-jsonstore, django-material, django-viewflow, libsass, packaging, python-dateutil, traitlets
 sqlparse==0.3.1           # via -r requirements/base.txt, django, django-debug-toolbar
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.3       # via faker

--- a/web/core/static/core/css/styles.scss
+++ b/web/core/static/core/css/styles.scss
@@ -1,0 +1,1 @@
+@import "./node_modules/govuk-frontend/govuk/all";

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -1,3 +1,6 @@
+{% load static %}
+{% load sass_tags %}
+
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 <head>
@@ -12,22 +15,16 @@
 
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/static/govuk/images/favicon.ico" type="image/x-icon">
-  <link rel="mask-icon" href="/static/govuk/images/govuk-mask-icon.svg" color="#0b0c0c">
-  <link rel="apple-touch-icon" sizes="180x180" href="/static/govuk/images/govuk-apple-touch-icon-180x180.png">
-  <link rel="apple-touch-icon" sizes="167x167" href="/static/govuk/images/govuk-apple-touch-icon-167x167.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/static/govuk/images/govuk-apple-touch-icon-152x152.png">
-  <link rel="apple-touch-icon" href="/static/govuk/images/govuk-apple-touch-icon.png">
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/static/govuk/assets/images/favicon.ico" type="image/x-icon">
+  <link rel="mask-icon" href="/static/govuk/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/govuk/assets/images/govuk-apple-touch-icon-180x180.png">
+  <link rel="apple-touch-icon" sizes="167x167" href="/static/govuk/assets/images/govuk-apple-touch-icon-167x167.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/static/govuk/assets/images/govuk-apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" href="/static/govuk/assets/images/govuk-apple-touch-icon.png">
 
+  <link rel="stylesheet" href="{% sass_src 'core/css/styles.scss' %}" type="text/css">
 
-  <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="/static/govuk/css/govuk-frontend-3.7.0.min.css">
-  <!--<![endif]-->
-  <!--[if IE 8]>
-    <link rel="stylesheet" href="/static/govuk/css/govuk-frontend-ie8-3.7.0.min.css">
-  <![endif]-->
-
-  <meta property="og:image" content="/static/govuk/images/govuk-opengraph-image.png">
+  <meta property="og:image" content="/static/govuk/assets/images/govuk-opengraph-image.png">
 
 </head>
 
@@ -45,7 +42,7 @@
           <span class="govuk-header__logotype">
             <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
               <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-              <image src="/static/govuk/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              <image src="/static/govuk/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
             </svg>
             <span class="govuk-header__logotype-text">
               GOV.UK
@@ -83,7 +80,7 @@
     </div>
   </footer>
   
-  <script src="/static/govuk/js/govuk-frontend-3.7.0.min.js"></script>
+  <script src="/static/govuk/all.js"></script>
   <script>
     window.GOVUKFrontend.initAll()
   </script>


### PR DESCRIPTION
- Use npm to install govuk-frontend
- Add nodejs buildpack to build node_modules during cf deployment
- Use django-sass-processor library to compile scss at runtime (compilescss added to procfile command)
- Include node_modules to static folders
- Create project stylesheet and import govuk scss (requires slightly hacky new url path 'assets/<asset>' as seen in other DIT projects)