### PR TITLE
Catch and log gov notify exceptions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-filter==2.3.0      # via -r requirements/base.in, django-viewflow
 django-jsonstore==0.4.1   # via django-viewflow
 django-material==1.6.3    # via -r requirements/base.in
 django-sass-processor==0.8  # via -r requirements/base.in
-git+https://github.com/uktrade/django-staff-sso-client.git@add_email_id_support#django-staff-sso-client  # via -r requirements/base.in
+git+https://github.com/uktrade/django-staff-sso-client.git@add_email_id_support#egg=django-staff-sso-client  # via -r requirements/base.in
 django-viewflow==1.6.0    # via -r requirements/base.in
 django==3.0.7             # via -r requirements/base.in, django-annoying, django-appconf, django-filter, django-jsonstore, django-staff-sso-client, django-viewflow, djangorestframework
 djangorestframework==3.11.0  # via -r requirements/base.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,11 +1,12 @@
 -r base.txt
-pytest==5.4.3
+django-debug-toolbar==2.2
+factory-boy==2.12.0
+flake8==3.8.3
+httpretty==1.0.2
+ipdb==0.13.3
 pytest-cov==2.10.0
 pytest-django==3.9.0
 pytest-dotenv==0.5.2
 pytest-sugar==0.9.3
-flake8==3.8.3
-factory-boy==2.12.0
-ipdb==0.13.3
-httpretty==1.0.2
-django-debug-toolbar==2.2
+pytest==5.4.3
+testfixtures==6.14.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ django-filter==2.3.0      # via -r requirements/base.txt, django-viewflow
 django-jsonstore==0.4.1   # via -r requirements/base.txt, django-viewflow
 django-material==1.6.3    # via -r requirements/base.txt
 django-sass-processor==0.8  # via -r requirements/base.txt
-git+https://github.com/uktrade/django-staff-sso-client.git@add_email_id_support#django-staff-sso-client  # via -r requirements/base.txt
+git+https://github.com/uktrade/django-staff-sso-client.git@add_email_id_support#egg=django-staff-sso-client  # via -r requirements/base.txt
 django-viewflow==1.6.0    # via -r requirements/base.txt
 django==3.0.7             # via -r requirements/base.txt, django-annoying, django-appconf, django-debug-toolbar, django-filter, django-jsonstore, django-staff-sso-client, django-viewflow, djangorestframework
 djangorestframework==3.11.0  # via -r requirements/base.txt
@@ -73,6 +73,7 @@ sentry-sdk==0.10.2        # via -r requirements/base.txt
 six==1.15.0               # via -r requirements/base.txt, django-annoying, django-compressor, django-jsonstore, django-material, django-viewflow, libsass, packaging, python-dateutil, traitlets
 sqlparse==0.3.1           # via -r requirements/base.txt, django, django-debug-toolbar
 termcolor==1.1.0          # via pytest-sugar
+testfixtures==6.14.1      # via -r requirements/dev.in
 text-unidecode==1.3       # via faker
 traitlets==4.3.3          # via ipython
 urllib3==1.25.9           # via -r requirements/base.txt, requests, sentry-sdk

--- a/web/core/notify.py
+++ b/web/core/notify.py
@@ -1,7 +1,10 @@
 import logging
 
+import requests
 from django.conf import settings
 from notifications_python_client import NotificationsAPIClient
+
+logger = logging.getLogger()
 
 
 class NotifyService:
@@ -32,11 +35,15 @@ class NotifyService:
         template_id = self.templates.get(template_name, {}).get('id')
 
         if settings.NOTIFY_ENABLED:
-            return self.api_client.send_email_notification(
-                email_address=email_address,
-                template_id=template_id,
-                personalisation=personalisation
-            )
+            try:
+                return self.api_client.send_email_notification(
+                    email_address=email_address,
+                    template_id=template_id,
+                    personalisation=personalisation
+                )
+            except requests.exceptions.HTTPError as e:
+                logger.error(e, exc_info=e)
+                return
 
         return self._preview_and_log(
             template_id=template_id,

--- a/web/core/tests/test_notify.py
+++ b/web/core/tests/test_notify.py
@@ -1,7 +1,11 @@
+import logging
 from unittest.mock import create_autospec
 
 from django.test import override_settings
 from notifications_python_client import NotificationsAPIClient
+from requests import HTTPError
+
+from testfixtures import LogCapture
 
 from web.core.notify import NotifyService
 from web.tests.helpers import BaseTestCase
@@ -30,3 +34,16 @@ class TestNotifyApplicationSubmittedEmail(BaseTestCase):
         )
         self.assertFalse(self.notifications_api_client.send_email_notification.called)
         self.assertTrue(self.notifications_api_client.post_template_preview.called)
+
+    @override_settings(NOTIFY_ENABLED=True)
+    def test_log_and_continue_on_notify_exception(self):
+        log_capture = LogCapture(level=logging.ERROR)
+        self.notifications_api_client.send_email_notification.side_effect = [HTTPError]
+        self.notify_client.send_application_submitted_email(
+            email_address='test@test.com', applicant_full_name='test'
+        )
+        log_capture.uninstall()
+        self.assertEqual(len(log_capture.records), 1)
+        self.assertEqual(log_capture.records[0].levelno, logging.ERROR)
+        self.assertTrue(self.notifications_api_client.send_email_notification.called)
+        self.assertFalse(self.notifications_api_client.post_template_preview.called)

--- a/web/grant_applications/admin.py
+++ b/web/grant_applications/admin.py
@@ -5,6 +5,6 @@ from web.grant_applications.models import GrantApplication
 
 @admin.register(GrantApplication)
 class GrantApplicationAdmin(admin.ModelAdmin):
-    fields = [field.name for field in GrantApplication._meta.get_fields()]
+    fields = [field.name for field in GrantApplication._meta.get_fields() if not field.is_relation]
     readonly_fields = ['id', 'created', 'updated']
     list_display = ['id', 'duns_number', 'created', 'updated']

--- a/web/tests/factories/grant_applications.py
+++ b/web/tests/factories/grant_applications.py
@@ -1,0 +1,38 @@
+from datetime import timedelta
+
+import factory
+from dateutil.utils import today
+
+from web.grant_applications.models import GrantApplication
+
+
+class GrantApplicationFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = GrantApplication
+
+    duns_number = factory.Sequence(lambda n: n)
+    applicant_full_name = factory.Sequence(lambda n: f'name-{n}')
+    applicant_email = factory.Sequence(lambda n: f'test{n}@test.com')
+    event = factory.Sequence(lambda n: f'event-{n}')
+    is_already_committed_to_event = True
+    is_intending_on_other_financial_support = True
+    has_previously_applied = True
+    previous_applications = 1
+    is_first_exhibit_at_event = True
+    number_of_times_exhibited_at_event = 0
+    goods_and_services_description = factory.Sequence(lambda n: f'description-{n}')
+    business_name_at_exhibit = factory.Sequence(lambda n: f'name-{n}')
+    turnover = 1000
+    number_of_employees = 1
+    sector = factory.Sequence(lambda n: f'sector-{n}')
+    website = factory.Sequence(lambda n: f'www.website-{n}.com')
+    has_exported_before = False
+    is_planning_to_grow_exports = True
+    is_seeking_export_opportunities = True
+    has_received_de_minimis_aid = False
+    de_minimis_aid_public_authority = factory.Sequence(lambda n: f'authority-{n}')
+    de_minimis_aid_date_awarded = factory.Sequence(lambda n: today() + timedelta(n))
+    de_minimis_aid_amount = 0
+    de_minimis_aid_description = factory.Sequence(lambda n: f'description-{n}')
+    de_minimis_aid_recipient = factory.Sequence(lambda n: f'recipient-{n}')
+    de_minimis_aid_date_received = factory.Sequence(lambda n: today() + timedelta(n))


### PR DESCRIPTION
In dev the gov Notify service can only send to a specified list of emails. If an applicant's email isnt on the list the library raises an exception