### PR TITLE
Frontend grant application flow change.

### DIFF
--- a/backoffice/web/grant_applications/models.py
+++ b/backoffice/web/grant_applications/models.py
@@ -142,7 +142,7 @@ class GrantApplication(BaseMetaModel):
         return qs.get()
 
     @property
-    def is_active(self):
+    def is_eligible(self):
         if self.previous_applications and self.previous_applications >= 6:
             return False
         if self.is_already_committed_to_event is True:

--- a/backoffice/web/grant_applications/serializers.py
+++ b/backoffice/web/grant_applications/serializers.py
@@ -73,7 +73,7 @@ class GrantManagementProcessSerializer(serializers.ModelSerializer):
 
 
 class GrantApplicationReadSerializer(serializers.ModelSerializer):
-    is_active = serializers.ReadOnlyField()
+    is_eligible = serializers.ReadOnlyField()
     sent_for_review = serializers.ReadOnlyField()
     company = CompanySerializer()
     event = EventSerializer()
@@ -86,17 +86,12 @@ class GrantApplicationReadSerializer(serializers.ModelSerializer):
 
 
 class GrantApplicationWriteSerializer(serializers.ModelSerializer):
-    is_active = serializers.ReadOnlyField()
+    is_eligible = serializers.ReadOnlyField()
     sent_for_review = serializers.ReadOnlyField()
 
     class Meta:
         model = GrantApplication
         fields = '__all__'
-
-    def validate(self, attrs):
-        if self.instance and not self.instance.is_active:
-            raise serializers.ValidationError('Grant application is inactive.')
-        return super().validate(attrs)
 
     def save(self, **kwargs):
         super(GrantApplicationWriteSerializer, self).save()

--- a/backoffice/web/grant_applications/tests/test_apis.py
+++ b/backoffice/web/grant_applications/tests/test_apis.py
@@ -10,7 +10,7 @@ from web.grant_management.models import GrantManagementProcess
 from web.tests.factories.companies import CompanyFactory
 from web.tests.factories.events import EventFactory
 from web.tests.factories.grant_applications import (
-    CompletedGrantApplicationFactory, GrantApplicationFactory, InactiveGrantApplicationFactory
+    CompletedGrantApplicationFactory, GrantApplicationFactory
 )
 from web.tests.factories.grant_management import GrantManagementProcessFactory
 from web.tests.factories.state_aid import StateAidFactory
@@ -30,7 +30,7 @@ class GrantApplicationsApiTests(BaseAPITestCase):
             response,
             data_contains={
                 'id': ga.id_str,
-                'is_active': ga.is_active,
+                'is_eligible': ga.is_eligible,
                 'previous_applications': ga.previous_applications,
                 'event': {
                     'id': ga.event.id_str,
@@ -182,14 +182,6 @@ class GrantApplicationsApiTests(BaseAPITestCase):
         response = self.client.patch(path, {'event': event.id})
         self.assertEqual(response.status_code, HTTP_200_OK, msg=response.data)
         self.assert_response_data_contains(response, data_contains={'event': event.id})
-
-    def test_cannot_update_inactive_grant_application(self, *mocks):
-        ga = InactiveGrantApplicationFactory()
-        self.assertFalse(ga.is_active)
-        path = reverse('grant-applications:grant-applications-detail', args=(ga.id,))
-        response = self.client.patch(path, {'is_already_committed_to_event': False})
-        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'][0].code, 'invalid')
 
     def test_create_new_grant_application_with_existing_company(self, *mocks):
         path = reverse('grant-applications:grant-applications-list')

--- a/backoffice/web/grant_applications/tests/test_models.py
+++ b/backoffice/web/grant_applications/tests/test_models.py
@@ -36,24 +36,24 @@ class TestGrantApplicationModel(BaseTestCase):
             GrantApplication.NumberOfEmployees.HAS_250_OR_MORE
         )
 
-    def test_new_grant_application_is_active(self, *mocks):
+    def test_new_grant_application_is_eligible(self, *mocks):
         ga = GrantApplicationFactory()
-        self.assertTrue(ga.is_active)
+        self.assertTrue(ga.is_eligible)
 
-    def test_grant_application_is_inactive_with_6_previous_applications(self, *mocks):
+    def test_grant_application_is_not_eligible_with_6_previous_applications(self, *mocks):
         ga = GrantApplicationFactory(previous_applications=6)
-        self.assertFalse(ga.is_active)
+        self.assertFalse(ga.is_eligible)
 
-    def test_grant_application_is_inactive_if_already_committed(self, *mocks):
+    def test_grant_application_is_not_eligible_if_already_committed(self, *mocks):
         ga = GrantApplicationFactory(is_already_committed_to_event=True)
-        self.assertFalse(ga.is_active)
+        self.assertFalse(ga.is_eligible)
 
-    def test_grant_application_is_inactive_with_number_of_employees(self, *mocks):
+    def test_grant_application_is_not_eligible_with_number_of_employees(self, *mocks):
         ga = GrantApplicationFactory(
             number_of_employees=GrantApplication.NumberOfEmployees.HAS_250_OR_MORE
         )
-        self.assertFalse(ga.is_active)
+        self.assertFalse(ga.is_eligible)
 
-    def test_grant_application_is_inactive_with_high_turnover(self, *mocks):
+    def test_grant_application_is_not_eligible_with_high_turnover(self, *mocks):
         ga = GrantApplicationFactory(is_turnover_greater_than=True)
-        self.assertFalse(ga.is_active)
+        self.assertFalse(ga.is_eligible)

--- a/frontend/web/core/view_mixins.py
+++ b/frontend/web/core/view_mixins.py
@@ -3,14 +3,6 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 
-class StaticContextMixin:
-    static_context = {}
-
-    def get_context_data(self, **kwargs):
-        kwargs.update(self.static_context)
-        return super().get_context_data(**kwargs)
-
-
 class BackContextMixin:
     back_text = None
     back_url = None
@@ -34,8 +26,11 @@ class BackContextMixin:
 
 
 class SuccessUrlObjectPkMixin:
+    success_url_name = None
 
     def get_success_url(self):
+        if self.object.has_viewed_review_page:
+            return reverse('grant-applications:application-review', args=(self.object.pk,))
         return reverse(self.success_url_name, args=(self.object.pk,))
 
 

--- a/frontend/web/grant_applications/templates/grant_applications/generic_form_page.html
+++ b/frontend/web/grant_applications/templates/grant_applications/generic_form_page.html
@@ -13,8 +13,8 @@
 {% block headings %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if page.caption %}<span class="govuk-caption-l">{{ page.caption }}</span>{% endif %}
-      <h2 class="govuk-heading-l">{{ page.heading|default:"Tradeshow Access Programme" }}</h2>
+      {% if page.caption %}<span class="govuk-caption-l" id="id_page_caption">{{ page.caption }}</span>{% endif %}
+      <h2 class="govuk-heading-l" id="id_page_heading">{{ page.heading|default:"Tradeshow Access Programme" }}</h2>
     </div>
   </div>
 {% endblock %}

--- a/frontend/web/grant_applications/tests/test_application_review_view.py
+++ b/frontend/web/grant_applications/tests/test_application_review_view.py
@@ -46,16 +46,16 @@ class TestApplicationReviewView(BaseTestCase):
         self.assertListEqual(
             [h.text for h in headings],
             [
-                PreviousApplicationsView.static_context['page']['heading'],
-                SelectAnEventView.static_context['page']['heading'],
-                EventCommitmentView.static_context['page']['heading'],
-                SelectCompanyView.static_context['page']['heading'],
-                CompanyDetailsView.static_context['page']['heading'],
-                ContactDetailsView.static_context['page']['heading'],
-                CompanyTradingDetailsView.static_context['page']['heading'],
-                ExportExperienceView.static_context['page']['heading'],
-                TradeEventDetailsView.static_context['page']['heading'],
-                StateAidSummaryView.static_context['page']['heading'],
+                PreviousApplicationsView.extra_context['page']['heading'],
+                SelectAnEventView.extra_context['page']['heading'],
+                EventCommitmentView.extra_context['page']['heading'],
+                SelectCompanyView.extra_context['page']['heading'],
+                CompanyDetailsView.extra_context['page']['heading'],
+                ContactDetailsView.extra_context['page']['heading'],
+                CompanyTradingDetailsView.extra_context['page']['heading'],
+                ExportExperienceView.extra_context['page']['heading'],
+                TradeEventDetailsView.extra_context['page']['heading'],
+                StateAidSummaryView.extra_context['page']['heading'],
             ]
         )
 
@@ -81,16 +81,16 @@ class TestApplicationReviewView(BaseTestCase):
         self.assertListEqual(
             [h.text for h in headings],
             [
-                PreviousApplicationsView.static_context['page']['heading'],
-                SelectAnEventView.static_context['page']['heading'],
-                EventCommitmentView.static_context['page']['heading'],
-                ManualCompanyDetailsView.static_context['page']['heading'],
-                CompanyDetailsView.static_context['page']['heading'],
-                ContactDetailsView.static_context['page']['heading'],
-                CompanyTradingDetailsView.static_context['page']['heading'],
-                ExportExperienceView.static_context['page']['heading'],
-                TradeEventDetailsView.static_context['page']['heading'],
-                StateAidSummaryView.static_context['page']['heading'],
+                PreviousApplicationsView.extra_context['page']['heading'],
+                SelectAnEventView.extra_context['page']['heading'],
+                EventCommitmentView.extra_context['page']['heading'],
+                ManualCompanyDetailsView.extra_context['page']['heading'],
+                CompanyDetailsView.extra_context['page']['heading'],
+                ContactDetailsView.extra_context['page']['heading'],
+                CompanyTradingDetailsView.extra_context['page']['heading'],
+                ExportExperienceView.extra_context['page']['heading'],
+                TradeEventDetailsView.extra_context['page']['heading'],
+                StateAidSummaryView.extra_context['page']['heading'],
             ]
         )
 
@@ -111,17 +111,17 @@ class TestApplicationReviewView(BaseTestCase):
         self.assertListEqual(
             [h.text for h in headings],
             [
-                PreviousApplicationsView.static_context['page']['heading'],
-                SelectAnEventView.static_context['page']['heading'],
-                EventCommitmentView.static_context['page']['heading'],
-                SelectCompanyView.static_context['page']['heading'],
-                CompanyDetailsView.static_context['page']['heading'],
-                ContactDetailsView.static_context['page']['heading'],
-                CompanyTradingDetailsView.static_context['page']['heading'],
-                ExportExperienceView.static_context['page']['heading'],
-                ExportDetailsView.static_context['page']['heading'],
-                TradeEventDetailsView.static_context['page']['heading'],
-                StateAidSummaryView.static_context['page']['heading'],
+                PreviousApplicationsView.extra_context['page']['heading'],
+                SelectAnEventView.extra_context['page']['heading'],
+                EventCommitmentView.extra_context['page']['heading'],
+                SelectCompanyView.extra_context['page']['heading'],
+                CompanyDetailsView.extra_context['page']['heading'],
+                ContactDetailsView.extra_context['page']['heading'],
+                CompanyTradingDetailsView.extra_context['page']['heading'],
+                ExportExperienceView.extra_context['page']['heading'],
+                ExportDetailsView.extra_context['page']['heading'],
+                TradeEventDetailsView.extra_context['page']['heading'],
+                StateAidSummaryView.extra_context['page']['heading'],
             ]
         )
 
@@ -202,21 +202,21 @@ class TestApplicationReviewView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[4].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[4].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[4].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True

--- a/frontend/web/grant_applications/tests/test_company_details_view.py
+++ b/frontend/web/grant_applications/tests/test_company_details_view.py
@@ -114,21 +114,21 @@ class TestCompanyDetailsView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -137,3 +137,20 @@ class TestCompanyDetailsView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, CompanyDetailsView.template_name)
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(
+            self.url,
+            data={
+                'number_of_employees': CompanyDetailsForm.NumberOfEmployees.HAS_FEWER_THAN_10,
+                'is_turnover_greater_than': True,
+                'is_already_committed_to_event': True
+            }
+        )
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:application-review', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )

--- a/frontend/web/grant_applications/tests/test_contact_details_view.py
+++ b/frontend/web/grant_applications/tests/test_contact_details_view.py
@@ -96,21 +96,21 @@ class TestContactDetailsView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -119,3 +119,21 @@ class TestContactDetailsView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, ContactDetailsView.template_name)
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(
+            self.url,
+            data={
+                'applicant_full_name': 'A Name',
+                'applicant_email': 'test@test.com',
+                'applicant_mobile_number': '+447777777777',
+                'job_title': 'director'
+            }
+        )
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:application-review', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )

--- a/frontend/web/grant_applications/tests/test_event_commitment_view.py
+++ b/frontend/web/grant_applications/tests/test_event_commitment_view.py
@@ -48,21 +48,21 @@ class TestEventCommitmentView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -71,6 +71,16 @@ class TestEventCommitmentView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, EventCommitmentView.template_name)
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(self.url, data={'is_already_committed_to_event': True})
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:application-review', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
 
     def test_post_data_is_saved(self, *mocks):
         self.client.post(self.url, data={'is_already_committed_to_event': True})

--- a/frontend/web/grant_applications/tests/test_export_details_view.py
+++ b/frontend/web/grant_applications/tests/test_export_details_view.py
@@ -80,21 +80,21 @@ class TestExportDetailsView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -103,3 +103,23 @@ class TestExportDetailsView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, ExportDetailsView.template_name)
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(
+            self.url,
+            data={
+                'has_exported_in_last_12_months': True,
+                'export_regions': ['africa', 'north america'],
+                'markets_intending_on_exporting_to': ['existing', 'new'],
+                'is_in_contact_with_dit_trade_advisor': True,
+                'export_experience_description': 'A description',
+                'export_strategy': 'A strategy'
+            }
+        )
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:application-review', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )

--- a/frontend/web/grant_applications/tests/test_find_an_event_view.py
+++ b/frontend/web/grant_applications/tests/test_find_an_event_view.py
@@ -77,21 +77,21 @@ class TestFindAnEventView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -100,6 +100,16 @@ class TestFindAnEventView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, FindAnEventView.template_name)
+
+    def test_post_redirects_to_event_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(self.url)
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:select-an-event', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
 
     def test_error_on_bad_query_param(self, *mocks):
         response = self.client.post(self.url, data={'filter_by_month': 'bad-value'})

--- a/frontend/web/grant_applications/tests/test_previous_applications_view.py
+++ b/frontend/web/grant_applications/tests/test_previous_applications_view.py
@@ -32,6 +32,12 @@ class TestPreviousApplicationsView(BaseTestCase):
         back_html = BeautifulSoup(response.content, 'html.parser').find(id='id_back_link')
         self.assertEqual(back_html.attrs['href'], reverse("grant-applications:before-you-start"))
 
+    def test_heading(self, *mocks):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        html = BeautifulSoup(response.content, 'html.parser').find(id='id_page_heading')
+        self.assertEqual(html.text, PreviousApplicationsView.extra_context['page']['heading'])
+
     def test_get_on_get_ga_backoffice_exception(self, *mocks):
         mocks[1].side_effect = BackofficeServiceException
         response = self.client.get(self.url)
@@ -49,21 +55,21 @@ class TestPreviousApplicationsView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -72,6 +78,19 @@ class TestPreviousApplicationsView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, PreviousApplicationsView.template_name)
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(
+            self.url,
+            data={'previous_applications': FAKE_GRANT_APPLICATION['previous_applications']}
+        )
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:application-review', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
 
     def test_post_updates_backoffice_grant_application(self, *mocks):
         response = self.client.post(

--- a/frontend/web/grant_applications/tests/test_search_company_view.py
+++ b/frontend/web/grant_applications/tests/test_search_company_view.py
@@ -96,21 +96,21 @@ class TestSearchCompanyView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[3].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[3].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -119,3 +119,15 @@ class TestSearchCompanyView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, SearchCompanyView.template_name)
+
+    def test_post_redirects_to_select_company_page_if_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(self.url, data={'search_term': 'company-1'})
+        self.assertRedirects(
+            response,
+            expected_url=reverse(
+                'grant-applications:select-company', args=(self.gal.pk,)
+            ) + '?search_term=company-1',
+            fetch_redirect_response=False
+        )

--- a/frontend/web/grant_applications/tests/test_select_an_event_view.py
+++ b/frontend/web/grant_applications/tests/test_select_an_event_view.py
@@ -120,21 +120,21 @@ class TestSelectAnEventView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[2].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -143,6 +143,16 @@ class TestSelectAnEventView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, SelectAnEventView.template_name)
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(self.url, data={'event': FAKE_EVENT['id']})
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:application-review', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
 
     def test_event_is_saved_on_form_continue_button(self, *mocks):
         response = self.client.post(self.url, data={'event': FAKE_EVENT['id']})

--- a/frontend/web/grant_applications/tests/test_state_aid_views.py
+++ b/frontend/web/grant_applications/tests/test_state_aid_views.py
@@ -77,21 +77,21 @@ class TestStateAidSummaryView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -100,6 +100,16 @@ class TestStateAidSummaryView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, StateAidSummaryView.template_name)
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(self.url)
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:application-review', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
 
 
 @patch.object(BackofficeService, 'get_state_aid', return_value=FAKE_STATE_AID)
@@ -202,21 +212,21 @@ class TestAddStateAidView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -225,6 +235,26 @@ class TestAddStateAidView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, AddStateAidView.template_name)
+
+    def test_post_redirects_to_state_aid_summary_page_if_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(
+            self.url,
+            data={
+                'authority': 'An authority',
+                'date_received_0': '01',
+                'date_received_1': '05',
+                'date_received_2': '2020',
+                'amount': 2000,
+                'description': 'A description',
+            }
+        )
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:state-aid-summary', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
 
 
 @patch.object(BackofficeService, 'list_state_aids', return_value=[FAKE_STATE_AID])
@@ -280,21 +310,21 @@ class TestEditStateAidView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
@@ -303,6 +333,16 @@ class TestEditStateAidView(BaseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, EditStateAidView.template_name)
+
+    def test_post_redirects_to_state_aid_summary_page_if_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
+        response = self.client.post(self.url, data={'amount': 2000})
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:state-aid-summary', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
 
 
 @patch.object(BackofficeService, 'delete_state_aid')
@@ -346,26 +386,36 @@ class TestDeleteStateAidView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[0].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[0].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
         self.gal.save()
 
+        response = self.client.get(self.url)
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:state-aid-summary', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
+
+    def test_redirects_to_state_aid_summary_page_if_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
         response = self.client.get(self.url)
         self.assertRedirects(
             response,
@@ -438,26 +488,36 @@ class TestDuplicateStateAidView(BaseTestCase):
 
     def test_get_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[0].return_value = fake_grant_application
         response = self.client.get(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_post_redirects_to_ineligible_if_application_is_not_active(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[0].return_value = fake_grant_application
         response = self.client.post(self.url)
         self.assertRedirects(response, reverse('grant-applications:ineligible'))
 
     def test_get_does_not_redirect_to_ineligible_if_review_page_has_been_viewed(self, *mocks):
         fake_grant_application = FAKE_GRANT_APPLICATION.copy()
-        fake_grant_application['is_active'] = False
+        fake_grant_application['is_eligible'] = False
         mocks[1].return_value = fake_grant_application
 
         self.gal.has_viewed_review_page = True
         self.gal.save()
 
+        response = self.client.get(self.url)
+        self.assertRedirects(
+            response,
+            reverse('grant-applications:state-aid-summary', args=(self.gal.pk,)),
+            fetch_redirect_response=False
+        )
+
+    def test_post_redirects_to_review_page_if_application_review_page_has_been_viewed(self, *mocks):
+        self.gal.has_viewed_review_page = True
+        self.gal.save()
         response = self.client.get(self.url)
         self.assertRedirects(
             response,

--- a/frontend/web/grant_applications/view_mixins.py
+++ b/frontend/web/grant_applications/view_mixins.py
@@ -68,7 +68,7 @@ class IneligibleRedirectMixin:
     def _is_eligible(self):
         if self.object.has_viewed_review_page:
             return True
-        elif not self.backoffice_grant_application.get('is_active', True):
+        elif not self.backoffice_grant_application.get('is_eligible', True):
             return False
         return True
 

--- a/frontend/web/tests/helpers/backoffice_objects.py
+++ b/frontend/web/tests/helpers/backoffice_objects.py
@@ -44,7 +44,7 @@ FAKE_SECTOR = {
 
 FAKE_GRANT_APPLICATION = {
     'id': '993c394c-dd5d-413c-bd70-1ba4f1e2b050',
-    'is_active': True,
+    'is_eligible': True,
     'previous_applications': 1,
     'event': FAKE_EVENT,
     'is_already_committed_to_event': True,


### PR DESCRIPTION
Success urls should redirect to review page if:
 - There are no pages/questions that depend on the answer to the current page
 - And the review page has been viewed previously

Success urls should NOT redirect to review page if:
 - There are pages/questions that depend on the answer to the current page
 - Or the review page has NOT yet been viewed