### PR TITLE
Moved event booking confirmation step to end of grant management flow

### DIFF
--- a/backoffice/web/grant_applications/tests/test_models.py
+++ b/backoffice/web/grant_applications/tests/test_models.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from web.grant_applications.models import GrantApplication
-from web.tests.factories.grant_applications import GrantApplicationFactory, CompletedGrantApplicationFactory
+from web.tests.factories.grant_applications import GrantApplicationFactory
 from web.tests.helpers import BaseTestCase
 
 
@@ -13,7 +13,7 @@ class TestGrantApplicationModel(BaseTestCase):
         self.assertFalse(ga.sent_for_review)
 
     def test_send_for_review_starts_flow_process(self, *mocks):
-        ga = CompletedGrantApplicationFactory()
+        ga = GrantApplicationFactory()
         ga.send_for_review()
         self.assertTrue(hasattr(ga, 'grant_management_process'))
         self.assertTrue(ga.sent_for_review)
@@ -37,23 +37,23 @@ class TestGrantApplicationModel(BaseTestCase):
         )
 
     def test_new_grant_application_is_eligible(self, *mocks):
-        ga = CompletedGrantApplicationFactory()
+        ga = GrantApplicationFactory()
         self.assertTrue(ga.is_eligible)
 
     def test_grant_application_is_not_eligible_with_6_previous_applications(self, *mocks):
-        ga = CompletedGrantApplicationFactory(previous_applications=6)
+        ga = GrantApplicationFactory(previous_applications=6)
         self.assertFalse(ga.is_eligible)
 
     def test_grant_application_is_not_eligible_if_already_committed(self, *mocks):
-        ga = CompletedGrantApplicationFactory(is_already_committed_to_event=True)
+        ga = GrantApplicationFactory(is_already_committed_to_event=True)
         self.assertFalse(ga.is_eligible)
 
     def test_grant_application_is_not_eligible_with_number_of_employees(self, *mocks):
-        ga = CompletedGrantApplicationFactory(
+        ga = GrantApplicationFactory(
             number_of_employees=GrantApplication.NumberOfEmployees.HAS_250_OR_MORE
         )
         self.assertFalse(ga.is_eligible)
 
     def test_grant_application_is_not_eligible_with_high_turnover(self, *mocks):
-        ga = CompletedGrantApplicationFactory(is_turnover_greater_than=True)
+        ga = GrantApplicationFactory(is_turnover_greater_than=True)
         self.assertFalse(ga.is_eligible)

--- a/backoffice/web/grant_management/flows.py
+++ b/backoffice/web/grant_management/flows.py
@@ -66,32 +66,7 @@ class GrantManagementFlow(Flow):
         task_title='Verify state eligibility'
     ).Next(this.finish_verify_tasks)
 
-    finish_verify_tasks = flow.Join().Next(this.request_event_booking_evidence)
-
-    request_event_booking_evidence = flow.View(
-        BaseGrantManagementView,
-        task_title='Request proof of event booking'
-    ).Next(this.send_event_booking_evidence_request_email_handler)
-
-    send_event_booking_evidence_request_email_handler = flow.Handler(
-        this.send_event_booking_evidence_request_email_callback
-    ).Next(this.create_review_evidence_task)
-
-    create_review_evidence_task = flow.Function(
-        this.create_review_evidence_of_event_booking,
-        task_loader=this.get_create_review_evidence_task,
-        task_title='Review proof of event booking'
-    ).Next(this.renew_proof_of_event_booking)
-
-    renew_proof_of_event_booking = flow.View(
-        BaseGrantManagementView,
-        form_class=EventBookingDocumentRenewForm,
-        task_title='Review proof of event booking'
-    ).Next(this.renew_proof_of_event_booking_handler)
-
-    renew_proof_of_event_booking_handler = flow.Handler(
-        this.send_renew_proof_of_event_booking_response_email_callback
-    ).Next(this.create_suitability_tasks)
+    finish_verify_tasks = flow.Join().Next(this.create_suitability_tasks)
 
     # Suitability tasks
     create_suitability_tasks = (
@@ -127,7 +102,32 @@ class GrantManagementFlow(Flow):
         task_title='Event is appropriate'
     ).Next(this.finish_suitability_tasks)
 
-    finish_suitability_tasks = flow.Join().Next(this.decision)
+    finish_suitability_tasks = flow.Join().Next(this.request_event_booking_evidence)
+
+    request_event_booking_evidence = flow.View(
+        BaseGrantManagementView,
+        task_title='Request proof of event booking'
+    ).Next(this.send_event_booking_evidence_request_email_handler)
+
+    send_event_booking_evidence_request_email_handler = flow.Handler(
+        this.send_event_booking_evidence_request_email_callback
+    ).Next(this.create_review_evidence_task)
+
+    create_review_evidence_task = flow.Function(
+        this.create_review_evidence_of_event_booking,
+        task_loader=this.get_create_review_evidence_task,
+        task_title='Review proof of event booking'
+    ).Next(this.renew_proof_of_event_booking)
+
+    renew_proof_of_event_booking = flow.View(
+        BaseGrantManagementView,
+        form_class=EventBookingDocumentRenewForm,
+        task_title='Review proof of event booking'
+    ).Next(this.renew_proof_of_event_booking_handler)
+
+    renew_proof_of_event_booking_handler = flow.Handler(
+        this.send_renew_proof_of_event_booking_response_email_callback
+    ).Next(this.decision)
 
     # Decision task
     decision = flow.View(


### PR DESCRIPTION
The PR changes related to moving the Viewflow task sequence of asking for event booking evidence and receiving event booking evidence to the step before a person approves the application.